### PR TITLE
[TDD] Add Test case for CMD method(ADD / DEL / MOD / SCH) int DataManager class

### DIFF
--- a/FriendsProject/dataManager.h
+++ b/FriendsProject/dataManager.h
@@ -1,6 +1,7 @@
 #include <string>
 #include <unordered_map>
 #include "employeeInfo.h"
+#include "CommandParser.h"
 #include <list>
 using namespace std;
 #define MAX_EMPLOYEE 100000
@@ -26,7 +27,7 @@ public:
 	unordered_map<int, list<EmployeeInfo*>> employeeNumMap;
 	unordered_map<string, list<EmployeeInfo*>> givenNameMap;
 	unordered_map<string, list<EmployeeInfo*>> familyNameMap;
-	unordered_map<int, list<EmployeeInfo*>> clMap;
+	unordered_map<CareerLevel, list<EmployeeInfo*>> clMap;
 	unordered_map<int, list<EmployeeInfo*>> phoneNumMidMap;
 	unordered_map<int, list<EmployeeInfo*>> phoneNumEndMap;
 	unordered_map<int, list<EmployeeInfo*>> birthYearMap;
@@ -37,4 +38,19 @@ public:
 	bool addEmployee(EmployeeInfo employee) {
 		return true;
 	}
+	int delEmployee(KeyInfo keyinfo) {
+		return 0;
+	}
+	int modEmployee(KeyInfo keyinfo) {
+		return 0;
+	}
+	int schEmployee(KeyInfo keyinfo) {
+		return 0;
+	}
+	void cmdCheck(CommandType cmd, EmployeeInfo& employeeinfo, KeyInfo& keyinfo) {
+
+	}
+
 };
+
+EmployeeInfo DataManager::employeePool[MAX_EMPLOYEE];

--- a/UnitTest/dataManager_cmd_test.cpp
+++ b/UnitTest/dataManager_cmd_test.cpp
@@ -1,0 +1,225 @@
+#include "pch.h"
+#include "../FriendsProject/employeeInfo.h"
+#include "../FriendsProject/dataManager.h"
+
+void input_test_data(DataManager* data_manager) { // test iuput data for cmd run
+	data_manager->addEmployee({ 00000000, "KILDONG", "HONG", CareerLevel::CL1, 1234, 5678, 1999, 12, 31, CERTI::ADV });
+	data_manager->addEmployee({ 00000001, "DONGKIL", "KIM", CareerLevel::CL2, 8765, 4321, 2000, 01, 01, CERTI::PRO });
+	data_manager->addEmployee({ 00000002, "KILDONG", "HONG", CareerLevel::CL1, 1234, 5678, 1999, 12, 31, CERTI::ADV });
+	data_manager->addEmployee({ 00000003, "DONGKIL", "KIM", CareerLevel::CL2, 8765, 4321, 2000, 01, 01, CERTI::PRO });
+	data_manager->addEmployee({ 00000004, "KILDONG", "HONG", CareerLevel::CL1, 1234, 5678, 1999, 12, 31, CERTI::ADV });
+}
+
+TEST(dataManagerTest, AddEmployeeTest_RedundancyTest) {
+	DataManager* data_manager = new DataManager();
+
+	EXPECT_TRUE(data_manager->addEmployee({ 00000000, "KILDONG", "HONG", CareerLevel::CL1, 1234, 5678, 1999, 12, 31, CERTI::ADV }));
+	EXPECT_TRUE(data_manager->addEmployee({ 00000001, "DONGKIL", "KIM", CareerLevel::CL2, 8765, 4321, 2000, 01, 01, CERTI::PRO }));
+	EXPECT_FALSE(data_manager->addEmployee({ 00000000, "KILDONG", "HONG", CareerLevel::CL1, 1234, 5678, 1999, 12, 31, CERTI::ADV }));
+}
+
+TEST(dataManagerTest, DelEmployeeTest_Num) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(1, data_manager->schEmployee({ "employeeNum", "00000000" }));
+	EXPECT_EQ(1, data_manager->schEmployee({ "employeeNum", "00000001" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "employeeNum", "00000000" }));
+}
+TEST(dataManagerTest, DelEmployeeTest_Name_Full) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->schEmployee({ "name", "KILDONG HONG" }));
+	EXPECT_EQ(2, data_manager->schEmployee({ "name", "DONGKIL KIM" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "name", "KILDONG HONG" }));
+}
+TEST(dataManagerTest, DelEmployeeTest_Name_Given) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->schEmployee({ "givenName", "KILDONG" }));
+	EXPECT_EQ(2, data_manager->schEmployee({ "givenName", "DONGKIL" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "givenName", "KILDONG" }));
+}
+TEST(dataManagerTest, DelEmployeeTest_Name_Family) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->schEmployee({ "familyName", "HONG" }));
+	EXPECT_EQ(2, data_manager->schEmployee({ "familyName", "KIM" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "familyName", "HONG" }));
+}
+TEST(dataManagerTest, DelEmployeeTest_Cl) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->schEmployee({ "cl", "1" }));
+	EXPECT_EQ(2, data_manager->schEmployee({ "cl", "2" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "cl", "1" }));
+}
+TEST(dataManagerTest, DelEmployeeTest_PhoneNum) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->schEmployee({ "phoneNum", "010-1234-5678" }));
+	EXPECT_EQ(2, data_manager->schEmployee({ "phoneNum", "010-8765-4321" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "phoneNum", "010-1234-5678" }));
+}
+TEST(dataManagerTest, DelEmployeeTest_PhoneNumMid) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->schEmployee({ "phoneNumMid", "1234" }));
+	EXPECT_EQ(2, data_manager->schEmployee({ "phoneNumMid", "8765" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "phoneNumMid", "1234" }));
+}
+TEST(dataManagerTest, DelEmployeeTest_PhoneNumEnd) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->schEmployee({ "phoneNumEnd", "5678" }));
+	EXPECT_EQ(2, data_manager->schEmployee({ "phoneNumEnd", "4321" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "phoneNumEnd", "5678" }));
+}
+TEST(dataManagerTest, DelEmployeeTest_Birth) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->schEmployee({ "birthday", "19991231" }));
+	EXPECT_EQ(2, data_manager->schEmployee({ "birthday", "20000101" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "birthday", "19991231" }));
+}
+TEST(dataManagerTest, DelEmployeeTest_BirthYear) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->schEmployee({ "birthdayYear", "1999" }));
+	EXPECT_EQ(2, data_manager->schEmployee({ "birthdayYear", "2000" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "birthdayYear", "1999" }));
+}
+TEST(dataManagerTest, DelEmployeeTest_BirthMonth) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->schEmployee({ "birthdayMonth", "12" }));
+	EXPECT_EQ(2, data_manager->schEmployee({ "birthdayMonth", "01" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "birthdayMonth", "12" }));
+}
+TEST(dataManagerTest, DelEmployeeTest_BirthDay) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->schEmployee({ "birthdayDay", "31" }));
+	EXPECT_EQ(2, data_manager->schEmployee({ "birthdayDay", "01" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "birthdayDay", "31" }));
+}
+TEST(dataManagerTest, DelEmployeeTest_Certi) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->schEmployee({ "certi", "ADV" }));
+	EXPECT_EQ(2, data_manager->schEmployee({ "certi", "PRO" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "certi", "ADV" }));
+}
+
+
+TEST(dataManagerTest, SchEmployeeTest_Num) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(1, data_manager->schEmployee({ "employeeNum", "00000000" }));
+	EXPECT_EQ(1, data_manager->schEmployee({ "employeeNum", "00000001" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "employeeNum", "00000006" }));
+}
+TEST(dataManagerTest, SchEmployeeTest_Name_Full) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->schEmployee({ "name", "KILDONG HONG" }));
+	EXPECT_EQ(2, data_manager->schEmployee({ "name", "DONGKIL KIM" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "name", "AAAAAAA AAAA" }));
+}
+TEST(dataManagerTest, SchEmployeeTest_Cl) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->schEmployee({ "cl", "1" }));
+	EXPECT_EQ(2, data_manager->schEmployee({ "cl", "2" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "cl", "3" }));
+}
+TEST(dataManagerTest, SchEmployeeTest_Phone) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->schEmployee({ "phoneNum", "010-1234-5678" }));
+	EXPECT_EQ(2, data_manager->schEmployee({ "phoneNum", "010-8765-4321" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "phoneNum", "010-0000-0000" }));
+}
+TEST(dataManagerTest, SchEmployeeTest_Birth) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->schEmployee({ "birthday", "19991231" }));
+	EXPECT_EQ(2, data_manager->schEmployee({ "birthday", "20000101" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "birthday", "20010615" }));
+}
+TEST(dataManagerTest, SchEmployeeTest_Certi) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->schEmployee({ "certi", "ADV" }));
+	EXPECT_EQ(2, data_manager->schEmployee({ "certi", "PRO" }));
+	EXPECT_EQ(0, data_manager->schEmployee({ "certi", "EX" }));
+}
+
+
+TEST(dataManagerTest, ModEmployeeTest_Num) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(1, data_manager->modEmployee({ "employeeNum", "00000000" , "name", "DONGKIL KIM" }));
+	EXPECT_EQ(1, data_manager->modEmployee({ "employeeNum", "00000001" , "name", "KILDONG HONG" }));
+	EXPECT_EQ(0, data_manager->modEmployee({ "employeeNum", "00000006" , "name", "KILDONG HONG" }));
+}
+TEST(dataManagerTest, ModEmployeeTest_Name_Full) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->modEmployee({ "name", "KILDONG HONG", "cl", "2" }));
+	EXPECT_EQ(2, data_manager->modEmployee({ "name", "DONGKIL KIM", "cl", "1" }));
+	EXPECT_EQ(0, data_manager->modEmployee({ "name", "AAAAAAA AAAA", "cl", "3" }));
+}
+TEST(dataManagerTest, ModEmployeeTest_Cl) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->modEmployee({ "cl", "1", "phoneNum", "010-8765-4321" }));
+	EXPECT_EQ(2, data_manager->modEmployee({ "cl", "2", "phoneNum", "010-1234-5678" }));
+	EXPECT_EQ(0, data_manager->modEmployee({ "cl", "3", "phoneNum", "010-0000-0000" }));
+}
+TEST(dataManagerTest, ModEmployeeTest_Phone) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->modEmployee({ "phoneNum", "010-1234-5678", "birthday", "20000101" }));
+	EXPECT_EQ(2, data_manager->modEmployee({ "phoneNum", "010-8765-4321", "birthday", "19991231" }));
+	EXPECT_EQ(0, data_manager->modEmployee({ "phoneNum", "010-0000-0000", "birthday", "20010615" }));
+}
+TEST(dataManagerTest, ModEmployeeTest_Birth) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->modEmployee({ "birthday", "19991231", "certi", "PRO" }));
+	EXPECT_EQ(2, data_manager->modEmployee({ "birthday", "20000101", "certi", "ADV" }));
+	EXPECT_EQ(0, data_manager->modEmployee({ "birthday", "20010615", "certi", "EX" }));
+}
+TEST(dataManagerTest, ModEmployeeTest_Certi) {
+	DataManager* data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	EXPECT_EQ(3, data_manager->modEmployee({ "certi", "ADV", "birthday", "20000101" }));
+	EXPECT_EQ(2, data_manager->modEmployee({ "certi", "PRO", "birthday", "19991231" }));
+	EXPECT_EQ(0, data_manager->modEmployee({ "certi", "EX", "birthday", "20010615" }));
+}
+

--- a/UnitTest/dataManager_test.cpp
+++ b/UnitTest/dataManager_test.cpp
@@ -8,7 +8,7 @@ TEST(dataManagerTest, employeeNumMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ i, "VXIHXOTH", "JHOP", 3, 3112, 2609, 77, 12, 11, ADV });  //사원번호가 i인 사람 생성
+		bool ret = data_manager.addEmployee({ i, "VXIHXOTH", "JHOP", 3, 3112, 2609, 77, 12, 11, CERTI::ADV });  //사원번호가 i인 사람 생성
 	};  
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
@@ -24,7 +24,7 @@ TEST(dataManagerTest, givenNameMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, to_string(i), "JHOP", 3, 3112, 2609, 77, 12, 11, ADV });  //givenname이 i인 사람 생성
+		bool ret = data_manager.addEmployee({ 15123099, to_string(i), "JHOP", 3, 3112, 2609, 77, 12, 11, CERTI::ADV });  //givenname이 i인 사람 생성
 	};
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
@@ -40,7 +40,7 @@ TEST(dataManagerTest, familyNameMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", to_string(i), 3, 3112, 2609, 77, 12, 11, ADV});  //familyname이 i인 사람 생성
+		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", to_string(i), 3, 3112, 2609, 77, 12, 11, CERTI::ADV});  //familyname이 i인 사람 생성
 	};
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
@@ -56,7 +56,7 @@ TEST(dataManagerTest, clMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", 3, ((i%3)+1), 2609, 77, 12, 11, ADV });  //cl이 i%3+1인 사람 생성
+		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", 3, ((i%3)+1), 2609, 77, 12, 11, CERTI::ADV });  //cl이 i%3+1인 사람 생성
 	};
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
@@ -72,7 +72,7 @@ TEST(dataManagerTest, phoneNumMidMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", 3, i, 2609, 77, 12, 11, ADV });  //사원번호가 i인 사람 생성
+		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", 3, i, 2609, 77, 12, 11, CERTI::ADV });  //사원번호가 i인 사람 생성
 	};
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
@@ -88,7 +88,7 @@ TEST(dataManagerTest, phoneNumEndMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", 3, 3112, i, 77, 12, 11, ADV });
+		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", 3, 3112, i, 77, 12, 11, CERTI::ADV });
 	};
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
@@ -105,7 +105,7 @@ TEST(dataManagerTest, birthYearMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", 3, 3112, 2609, i, 12, 11, ADV });
+		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", 3, 3112, 2609, i, 12, 11, CERTI::ADV });
 	};
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
@@ -122,7 +122,7 @@ TEST(dataManagerTest, birthMonthMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", 3, 3112, 2609, 77, i, 11, ADV });
+		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", 3, 3112, 2609, 77, i, 11, CERTI::ADV });
 	};
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
@@ -138,7 +138,7 @@ TEST(dataManagerTest, birthDayMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", 3, 3112, 2609, 77, 12, i, ADV });
+		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", 3, 3112, 2609, 77, 12, i, CERTI::ADV });
 	};
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test


### PR DESCRIPTION
parseCommand를 통해서 얻게 된 EmployeeInfo 및 KeyInfo를 통해서 각 CDM 별로 동작이 구현되도록 함수 명 선언 및 이와 관련된 테스트 케이스를 구현해 보았습니다.

또한, Employee Info 중, CL 및 Certi에 대한 자료형 수정에 따라 발생하는 기존 코드의 버그도 같이 수정 진행했습니다.
감사합니다.