### PR TITLE
[TDD] printer 함수 틀 및 unit test 추가

### DIFF
--- a/FriendsProject/FriendsProject.vcxproj
+++ b/FriendsProject/FriendsProject.vcxproj
@@ -143,12 +143,14 @@
     <ClCompile Include="del.cpp" />
     <ClCompile Include="employeeInfo.cpp" />
     <ClCompile Include="employeeManagement.cpp" />
+    <ClCompile Include="printer.cpp" />
     <ClCompile Include="search.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CommandParser.h" />
     <ClInclude Include="dataManager.h" />
     <ClInclude Include="employeeInfo.h" />
+    <ClInclude Include="printer.h" />
     <ClInclude Include="search.h" />
     <ClInclude Include="employeeManagement.h" />
   </ItemGroup>

--- a/FriendsProject/FriendsProject.vcxproj.filters
+++ b/FriendsProject/FriendsProject.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="dataManager.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="printer.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="employeeInfo.h">
@@ -45,6 +48,9 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="dataManager.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="printer.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/FriendsProject/printer.cpp
+++ b/FriendsProject/printer.cpp
@@ -1,0 +1,14 @@
+#include "printer.h"
+
+const string CommandString[] = { "ADD", "MOD", "SCH", "DEL" };
+
+string Printer::getFullDataString(list<EmployeeInfo*> dataList) {
+	return NULL;
+}
+
+string Printer::printResultwithOption(CommandType cmd, list<EmployeeInfo*>* dataList) {
+	return NULL;
+}
+string Printer::printResultwithoutOption(CommandType cmd, int num) {
+	return NULL;
+}

--- a/FriendsProject/printer.h
+++ b/FriendsProject/printer.h
@@ -1,0 +1,10 @@
+#include <list>
+#include "CommandParser.h"
+
+class Printer {
+private:
+	string getFullDataString(list<EmployeeInfo*> dataList);
+public:
+	string printResultwithOption(CommandType cmd, list<EmployeeInfo*>* dataList);
+	string printResultwithoutOption(CommandType cmd, int num);
+};

--- a/UnitTest/UnitTest.vcxproj
+++ b/UnitTest/UnitTest.vcxproj
@@ -41,6 +41,7 @@
     <ClCompile Include="employeeManagement_test.cpp" />
     <ClCompile Include="dataManager_test.cpp" />
     <ClCompile Include="del_test.cpp" />
+    <ClCompile Include="printer_test.cpp" />
     <ClCompile Include="search_test.cpp" />
     <ClCompile Include="test.cpp" />
     <ClCompile Include="pch.cpp">

--- a/UnitTest/dataManager_cmd_test.cpp
+++ b/UnitTest/dataManager_cmd_test.cpp
@@ -1,5 +1,5 @@
 #include "pch.h"
-#include "../FriendsProject/employeeInfo.h"
+//#include "../FriendsProject/employeeInfo.h"
 #include "../FriendsProject/dataManager.h"
 
 void input_test_data(DataManager* data_manager) { // test iuput data for cmd run

--- a/UnitTest/printer_test.cpp
+++ b/UnitTest/printer_test.cpp
@@ -1,0 +1,175 @@
+#include "pch.h"
+#include "../FriendsProject/printer.cpp"
+#include "../FriendsProject/dataManager.h"
+#include "../FriendsProject/search.h"
+#include <iostream>
+
+Printer printer;
+DataManager* data_manager;
+
+extern void input_test_data(DataManager* data_manager);
+
+TEST(PrintTest, DELwithoutOption) {
+	data_manager = new DataManager();
+	input_test_data(data_manager);
+	
+	list<EmployeeInfo*>* result = nullptr;
+	//result =  data_manager->schEmployee({ "employeeNum", "00000000" }); 
+
+	string resultString = "DEL,1";
+	cout << resultString + "\n";
+
+	if (result != nullptr)
+		EXPECT_EQ(resultString, printer.printResultwithoutOption(CommandType::DEL, result->size()));
+	else {
+		EXPECT_TRUE(false);
+		cout << "failed to get employeeInfo";
+	}
+}
+
+TEST(PrintTest, DELwithOption) {
+	data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	list<EmployeeInfo*>* result = nullptr;
+	//result =  data_manager->schEmployee({ "employeeNum", "00000000" }); 
+
+	string resultString = "DEL,00000000,HONG KILDONG,CL1,010-1234-5678,19991231,ADV";
+	cout << resultString + "\n";
+
+	if (result != nullptr)
+		EXPECT_EQ(resultString, printer.printResultwithOption(CommandType::DEL, result));
+	else {
+		EXPECT_TRUE(false);
+		cout << "failed to get employeeInfo";
+	}
+}
+
+TEST(PrintTest, DELwithOptionNoResult) {
+	data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	list<EmployeeInfo*>* result = nullptr;
+	//result =  data_manager->schEmployee({ "employeeNum", "99999999" }); 
+
+	string resultString = "DEL,NONE";
+	cout << resultString + "\n";
+
+	if (result != nullptr)
+		EXPECT_EQ(resultString, printer.printResultwithOption(CommandType::DEL, result));
+	else {
+		EXPECT_TRUE(false);
+		cout << "failed to get employeeInfo";
+	}
+}
+
+TEST(PrintTest, MODwithoutOption) {
+	data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	list<EmployeeInfo*>* result = nullptr;
+	//result =  data_manager->schEmployee({ "cl", "1" }); 
+
+	string resultString = "MOD,3";
+	cout << resultString + "\n";
+
+	if (result != nullptr)
+		EXPECT_EQ(resultString, printer.printResultwithoutOption(CommandType::MOD, result->size()));
+	else {
+		EXPECT_TRUE(false);
+		cout << "failed to get employeeInfo";
+	}
+}
+
+TEST(PrintTest, MODwithOption) {
+	data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	list<EmployeeInfo*>* result = nullptr;
+	//result =  data_manager->schEmployee({ "cl", "1" }); 
+
+	string resultString = "MOD,00000000,HONG KILDONG,CL1,010-1234-5678,19991231,ADV\n \
+							MOD,00000002,HONG KILDONG,CL1,010-1234-5678,19991231,ADV\n \
+							MOD,00000004,HONG KILDONG,CL1,010-1234-5678,19991231,ADV";
+	cout << resultString + "\n";
+
+	if (result != nullptr)
+		EXPECT_EQ(resultString, printer.printResultwithOption(CommandType::MOD, result));
+	else {
+		EXPECT_TRUE(false);
+		cout << "failed to get employeeInfo";
+	}
+}
+
+TEST(PrintTest, MODwithOptionNoResult) {
+	data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	list<EmployeeInfo*>* result = nullptr;
+	//result =  data_manager->schEmployee({ "cl", "4" }); 
+
+	string resultString = "MOD,NONE";
+	cout << resultString + "\n";
+
+	if (result != nullptr)
+		EXPECT_EQ(resultString, printer.printResultwithOption(CommandType::MOD, result));
+	else {
+		EXPECT_TRUE(false);
+		cout << "failed to get employeeInfo";
+	}
+}
+
+TEST(PrintTest, SCHwithoutOption) {
+	data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	list<EmployeeInfo*>* result = nullptr;
+	//result =  data_manager->schEmployee({ "familyname", "KIM" }); 
+
+	string resultString = "SCH,2";
+	cout << resultString + "\n";
+
+	if (result != nullptr)
+		EXPECT_EQ(resultString, printer.printResultwithoutOption(CommandType::SCH, result->size()));
+	else {
+		EXPECT_TRUE(false);
+		cout << "failed to get employeeInfo";
+	}
+}
+
+TEST(PrintTest, SCHwithOption) {
+	data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	list<EmployeeInfo*>* result = nullptr;
+	//result =  data_manager->schEmployee({ "familyname", "KIM" }); 
+
+	string resultString = "SCH,00000001,KIM DONGKIL,CL2,010-8765-4321,20000101,ADV\n \
+							SCH,00000001,KIM DONGKIL,CL2,010-8765-4321,20000101,ADV";
+	cout << resultString + "\n";
+
+	if (result != nullptr)
+		EXPECT_EQ(resultString, printer.printResultwithOption(CommandType::SCH, result));
+	else {
+		EXPECT_TRUE(false);
+		cout << "failed to get employeeInfo";
+	}
+}
+
+TEST(PrintTest, SCHwithoutOptionNoResult) {
+	data_manager = new DataManager();
+	input_test_data(data_manager);
+
+	list<EmployeeInfo*>* result = nullptr;
+	//result =  data_manager->schEmployee({ "familyname", "LEE" }); 
+
+	string resultString = "SCH,NONE";
+	cout << resultString + "\n";
+
+	if (result != nullptr)
+		EXPECT_EQ(resultString, printer.printResultwithoutOption(CommandType::MOD, result->size()));
+	else {
+		EXPECT_TRUE(false);
+		cout << "failed to get employeeInfo";
+	}
+}


### PR DESCRIPTION
printer 기능의 class 및 unit test를 추가하였습니다.

- 테스트 코드에 주석으로 처리된 부분은 dataManager->schEmployee() 의 리턴이 현재 int type이기 때문에 지정해두었습니다.
검색 결과를 list<Employee*>* 로 받아와야 해당 값을 print할 수 있을 것으로 보입니다.

- 또한 print 함수의 호출 시점이 중요한데요, delete나 mod를 수행하기 '이전'에 불려야 합니다..!

- 테스트 확인 및 활용성을 위해 우선 return type을 string으로 했는데요,
output file writer를 freopen을 활용하실 경우, 
해당 파일에 쓰는 동작(이 경우 cout)을 print 함수에서 하는 게 나을까요?
아니면 command 수행 중 print함수를 호출하는 주체에서 하는 게 나을까요?
