### PR TITLE
[TDD][bugfix] parser => add module 정상동작 확인

### DIFF
--- a/FriendsProject/dataManager.cpp
+++ b/FriendsProject/dataManager.cpp
@@ -53,7 +53,7 @@ bool DataManager::addEmployee(EmployeeInfo employee) {
 	employeePool[employeeCnt] = employee;
 	auto iter = employeeNumMap.find(employee.employeeNum);
 	if (iter == employeeNumMap.end())
-		employeeNumMap.insert({ employeeCnt,	list<EmployeeInfo*> { &(employeePool[employeeCnt])} }); //employ number는 무조건 하나
+		employeeNumMap.insert({ employee.employeeNum,	list<EmployeeInfo*> { &(employeePool[employeeCnt])} }); //employ number는 무조건 하나
 	else
 		return false;
 

--- a/FriendsProject/employeeManagement.h
+++ b/FriendsProject/employeeManagement.h
@@ -2,6 +2,7 @@
 #include <string>
 #include "employeeInfo.h"
 #include "CommandParser.h"
+#include "dataManager.h"
 #include <iostream>
 
 #define MAX_READ_BUFFER_SIZE	(512)
@@ -52,9 +53,9 @@ public:
 
 	int prepareCommand(int lineIndex) {
 		CommandParser* cp = new CommandParser();
-		EmployeeInfo* addInfo = new EmployeeInfo();
-		KeyInfo* keyInfo = new KeyInfo();
-		OptionInfo* optionInfo = new OptionInfo();
+		addInfo = new EmployeeInfo();
+		keyInfo = new KeyInfo();
+		optionInfo = new OptionInfo();
 
 		commandType = cp->parseData(readLine[lineIndex]);
 		cp->parseOption(optionInfo);
@@ -75,12 +76,11 @@ public:
 
 	int runCommand() {
 
-		//DataManager* dm = new DataManager();
-
-		//switch (commandType) {
-		//case CommandType::ADD:
-		//	result = dm->runAdd(addInfo);
-		//	break;
+		bool result;
+		switch (commandType) {
+		case CommandType::ADD:
+			result = dm->addEmployee(*addInfo);
+			break;
 		//case CommandType::MOD:
 		//	result = dm->runModify(keyInfo);
 		//	break;
@@ -90,9 +90,9 @@ public:
 		//case CommandType::DEL:
 		//	result = dm->runDelete(keyInfo);
 		//	break;
-		//default:
-		//	result = -1;
-		//}
+		default:
+			result = true;
+		}
 
 		return 0;
 	}
@@ -102,6 +102,7 @@ public:
 		return 0;
 	}
 
+	DataManager* dm = new DataManager();
 	CommandType commandType;
 	EmployeeInfo* addInfo;
 	KeyInfo* keyInfo;

--- a/UnitTest/CommandParser_test.cpp
+++ b/UnitTest/CommandParser_test.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "../FriendsProject/CommandParser.h"
 #include "../FriendsProject/employeeManagement.h"
+#include "../FriendsProject/dataManager.h"
 
 TEST(CommandParserTest, parse_data) {
 	EmployeeManagement* em = new EmployeeManagement();
@@ -162,4 +163,36 @@ TEST(CommandParserTest, parse_option) {
 	// SCH, ,-f, ,name,LDEXRI
 	EXPECT_EQ(keyInfo->searchKey, "givenName");
 	EXPECT_EQ(keyInfo->searchKeyword, "LDEXRI");
+}
+
+TEST(CommandParserTest, parse_addmodule) {
+	EmployeeManagement* em = new EmployeeManagement();
+	CommandParser* cp = new CommandParser();
+	EmployeeInfo* addInfo = new EmployeeInfo();
+	OptionInfo* optionInfo = new OptionInfo();
+	DataManager* dm = new DataManager();
+
+	ASSERT_EQ(em->openFile("../FriendsProject/input_20_20.txt", ""), 0);
+	ASSERT_EQ(em->loadData(), 40);
+
+	cp->parseData(em->readLine[0]);
+	cp->parseAddCommand(addInfo);
+	dm->addEmployee(*addInfo);
+
+	// ADD, , , ,15123099,VXIHXOTH JHOP,CL3,010-3112-2609,19771211,ADV
+	EmployeeInfo* employee = *(dm->employeeNumMap[15123099].begin());
+	
+	EXPECT_EQ(employee->employeeNum, 15123099);
+	EXPECT_EQ(employee->givenName, "VXIHXOTH");
+	EXPECT_EQ(employee->familyName, "JHOP");
+	EXPECT_EQ(employee->cl, CareerLevel::CL3);
+	EXPECT_EQ(employee->phoneNumMid, 3112);
+	EXPECT_EQ(employee->phoneNumEnd, 2609);
+	EXPECT_EQ(employee->birthYear, 1977);
+	EXPECT_EQ(employee->birthMonth, 12);
+	EXPECT_EQ(employee->birthDay, 11);
+	EXPECT_EQ(employee->certi, CERTI::ADV);
+	EXPECT_EQ(employee->name, "VXIHXOTH JHOP");
+	EXPECT_EQ(employee->phoneNum, "010-3112-2609");
+	EXPECT_EQ(employee->birth, 19771211);
 }


### PR DESCRIPTION
Parser와 add module을 연결지을 때, 발견한 bug를 수정하고 검증하였습니다.
1) DataManager::addModule 함수에서 사번 대신, 저장된 employee에 명수를 key로 사용하는 bug 수정
2) EmployeeManagement::prepareCommand에서 멤버 변수가 아닌 지역변수 사용하는 bug 수정

TDD를 활용하여 이를 검증하였습니다. 입력 parse하고, add module까지 넘어가여 잘 저장되고 있습니다. 