### PR TITLE
[Refactoring] employeeInfo의 변수 naming 수정

### DIFF
--- a/FriendsProject/CommandParser.h
+++ b/FriendsProject/CommandParser.h
@@ -76,8 +76,8 @@ public:
 			return -1;
 
 		addInfo->name = parseLine[5];
-		addInfo->givenName = name_split[0];
-		addInfo->familyName = name_split[1];
+		addInfo->name_First = name_split[0];
+		addInfo->name_Last = name_split[1];
 
 		addInfo->cl = (CareerLevel)(atoi(parseLine[6].substr(2, 1).c_str()) - 1);
 		if ((addInfo->cl < CareerLevel::CL1) || (addInfo->cl > CareerLevel::CL4))
@@ -88,14 +88,14 @@ public:
 			return -1;
 
 		addInfo->phoneNum = parseLine[7];
-		addInfo->phoneNumMid = atoi(phone_split[1].c_str());
-		addInfo->phoneNumEnd = atoi(phone_split[2].c_str());
+		addInfo->phoneNum_Mid = atoi(phone_split[1].c_str());
+		addInfo->phoneNum_End = atoi(phone_split[2].c_str());
 
 		// TODO: add birth invalid condition
-		addInfo->birth = atoi(parseLine[8].c_str());
-		addInfo->birthYear = atoi(parseLine[8].substr(0, 4).c_str());
-		addInfo->birthMonth = atoi(parseLine[8].substr(4, 2).c_str());
-		addInfo->birthDay = atoi(parseLine[8].substr(6, 2).c_str());
+		addInfo->birthday = atoi(parseLine[8].c_str());
+		addInfo->birthday_Year = atoi(parseLine[8].substr(0, 4).c_str());
+		addInfo->birthday_Month = atoi(parseLine[8].substr(4, 2).c_str());
+		addInfo->birthday_Day = atoi(parseLine[8].substr(6, 2).c_str());
 
 		string lastStr = parseLine[9].substr(0, (parseLine[9].length() - 1));
 		if (lastStr == "ADV") addInfo->certi = CERTI::ADV;
@@ -107,9 +107,9 @@ public:
 	}
 
 	const string searchOptionKeyStr[3][4] = {
-		{"name","givenName","name","familyName"},
-		{"phoneNum","phoneNum","phoneNumMid","phoneNumEnd"},
-		{"birthday","birthYear","birthMonth","birthDay"}
+		{"name","name_First","name","name_Last"},
+		{"phoneNum","phoneNum","phoneNum_Mid","phoneNum_End"},
+		{"birthday","birthday_Year","birthday_Month","birthday_Day"}
 	};
 
 	string getSearchKeyStr(string key, OptionInfo* optionInfo) {

--- a/FriendsProject/dataManager.cpp
+++ b/FriendsProject/dataManager.cpp
@@ -63,17 +63,17 @@ bool DataManager::addEmployee(EmployeeInfo employee) {
 	employeeInfoMap.insert({ employeenumber, &employeePool[employeeCnt] });
 
 	employeeNumMap.insert({ employee.employeeNum, employeenumber });
-	givenNameMap.insert({ employee.givenName, employeenumber });
-	familyNameMap.insert({ employee.familyName, employeenumber });
+	givenNameMap.insert({ employee.name_First, employeenumber });
+	familyNameMap.insert({ employee.name_Last, employeenumber });
 	nameMap.insert({ employee.name, employeenumber });
 	clMap.insert({ employee.cl , employeenumber });
-	phoneNumMidMap.insert({ employee.phoneNumMid, employeenumber });
-	phoneNumEndMap.insert({ employee.phoneNumEnd, employeenumber });
+	phoneNumMidMap.insert({ employee.phoneNum_Mid, employeenumber });
+	phoneNumEndMap.insert({ employee.phoneNum_End, employeenumber });
 	phoneNumMap.insert({ employee.phoneNum, employeenumber });
-	birthYearMap.insert({ employee.birthYear, employeenumber });
-	birthMonthMap.insert({ employee.birthMonth, employeenumber });
-	birthDayMap.insert({ employee.birthDay, employeenumber });
-	birthMap.insert({ employee.birth, employeenumber });
+	birthYearMap.insert({ employee.birthday_Year, employeenumber });
+	birthMonthMap.insert({ employee.birthday_Month, employeenumber });
+	birthDayMap.insert({ employee.birthday_Day, employeenumber });
+	birthMap.insert({ employee.birthday, employeenumber });
 	certiMap.insert({ employee.certi, employeenumber });
 
 	employeeCnt++;

--- a/FriendsProject/dataManager.h
+++ b/FriendsProject/dataManager.h
@@ -320,12 +320,12 @@ public:
 		if (keyinfo.modifyKey == "name") {
 			employeeinfo->name = keyinfo.modifyKeyword;
 			int idx = keyinfo.modifyKeyword.find(' ');
-			employeeinfo->givenName = keyinfo.modifyKeyword.substr(0, idx);
-			employeeinfo->familyName = keyinfo.modifyKeyword.substr(idx + 1);
+			employeeinfo->name_First = keyinfo.modifyKeyword.substr(0, idx);
+			employeeinfo->name_Last = keyinfo.modifyKeyword.substr(idx + 1);
 
 			nameMap.insert({ employeeinfo->name, employeeNum });
-			givenNameMap.insert({ employeeinfo->givenName, employeeNum });
-			familyNameMap.insert({ employeeinfo->familyName, employeeNum });
+			givenNameMap.insert({ employeeinfo->name_First, employeeNum });
+			familyNameMap.insert({ employeeinfo->name_Last, employeeNum });
 		}
 		else if (keyinfo.modifyKey == "cl") {
 			employeeinfo->cl = getCL(keyinfo.modifyKeyword);
@@ -336,23 +336,23 @@ public:
 			employeeinfo->phoneNum = keyinfo.modifyKeyword;
 			int idx1 = keyinfo.modifyKeyword.find('-', 0);
 			int idx2 = keyinfo.modifyKeyword.find('-', idx1 + 1);
-			employeeinfo->phoneNumMid = stoi(keyinfo.modifyKeyword.substr(idx1 + 1, idx2 - idx1));
-			employeeinfo->phoneNumEnd = stoi(keyinfo.modifyKeyword.substr(idx2 + 1));
+			employeeinfo->phoneNum_Mid = stoi(keyinfo.modifyKeyword.substr(idx1 + 1, idx2 - idx1));
+			employeeinfo->phoneNum_End = stoi(keyinfo.modifyKeyword.substr(idx2 + 1));
 
 			phoneNumMap.insert({ employeeinfo->phoneNum, employeeNum });
-			phoneNumMidMap.insert({ employeeinfo->phoneNumMid, employeeNum });
-			phoneNumEndMap.insert({ employeeinfo->phoneNumEnd, employeeNum });
+			phoneNumMidMap.insert({ employeeinfo->phoneNum_Mid, employeeNum });
+			phoneNumEndMap.insert({ employeeinfo->phoneNum_End, employeeNum });
 		}
 		else if (keyinfo.modifyKey == "birthday") {
-			employeeinfo->birth = stoi(keyinfo.modifyKeyword);
-			employeeinfo->birthYear = stoi(keyinfo.modifyKeyword.substr(0, 4));
-			employeeinfo->birthMonth = stoi(keyinfo.modifyKeyword.substr(4, 2));
-			employeeinfo->birthDay = stoi(keyinfo.modifyKeyword.substr(6, 2));
+			employeeinfo->birthday = stoi(keyinfo.modifyKeyword);
+			employeeinfo->birthday_Year = stoi(keyinfo.modifyKeyword.substr(0, 4));
+			employeeinfo->birthday_Month = stoi(keyinfo.modifyKeyword.substr(4, 2));
+			employeeinfo->birthday_Day = stoi(keyinfo.modifyKeyword.substr(6, 2));
 
-			birthMap.insert({ employeeinfo->birth , employeeNum });
-			birthYearMap.insert({ employeeinfo->birthYear , employeeNum });
-			birthMonthMap.insert({ employeeinfo->birthMonth , employeeNum });
-			birthDayMap.insert({ employeeinfo->birthDay , employeeNum });
+			birthMap.insert({ employeeinfo->birthday , employeeNum });
+			birthYearMap.insert({ employeeinfo->birthday_Year , employeeNum });
+			birthMonthMap.insert({ employeeinfo->birthday_Month , employeeNum });
+			birthDayMap.insert({ employeeinfo->birthday_Day , employeeNum });
 		}
 		else if (keyinfo.modifyKey == "certi") {
 			employeeinfo->certi = getCerti(keyinfo.modifyKeyword);

--- a/FriendsProject/employeeInfo.h
+++ b/FriendsProject/employeeInfo.h
@@ -21,16 +21,16 @@ enum class CareerLevel {
 class EmployeeInfo {
 public:
 	int employeeNum;
-	string givenName;
-	string familyName;
+	string name_First;
+	string name_Last;
 	CareerLevel cl;
-	int phoneNumMid;
-	int phoneNumEnd;
-	int birthYear;
-	int birthMonth;
-	int birthDay;
+	int phoneNum_Mid;
+	int phoneNum_End;
+	int birthday_Year;
+	int birthday_Month;
+	int birthday_Day;
 	CERTI certi;
 	string name;
 	string phoneNum;
-	int birth;
+	int birthday;
 };

--- a/FriendsProject/printer.cpp
+++ b/FriendsProject/printer.cpp
@@ -27,7 +27,7 @@ string Printer::generateString(EmployeeInfo* data) {
 	addCommaData(dataString, data->name);
 	addCommaData(dataString, careerLevelString[static_cast<int>(data->cl)]);
 	addCommaData(dataString, data->phoneNum);
-	addCommaData(dataString, to_string(data->birth));
+	addCommaData(dataString, to_string(data->birthday));
 	addCommaData(dataString, certiString[static_cast<int>(data->certi)]);
 
 	return dataString;

--- a/FriendsProject/search.cpp
+++ b/FriendsProject/search.cpp
@@ -7,14 +7,14 @@ const list<EmployeeInfo*> SearchEngine::search(string key, unordered_multimap<st
 	for (auto it = range.first; it != range.second;) {
 		if (employeeInfoMap.find(it->second) != employeeInfoMap.end()) {
 			if (hash_name == "givenNameMap") {
-				if (employeeInfoMap.find(it->second)->second->givenName != key) {
+				if (employeeInfoMap.find(it->second)->second->name_First != key) {
 					hashTable.erase(it++);
 					continue;
 				}
 				result.push_back(employeeInfoMap[it->second]);
 			}
 			else if (hash_name == "familyNameMap") {
-				if (employeeInfoMap.find(it->second)->second->familyName != key) {
+				if (employeeInfoMap.find(it->second)->second->name_Last != key) {
 					hashTable.erase(it++);
 					continue;
 				}
@@ -53,42 +53,42 @@ const list<EmployeeInfo*> SearchEngine::search(int key, unordered_multimap<int, 
 				result.push_back(employeeInfoMap[it->second]);
 			}
 			else if (hash_name == "phoneNumMidMap") {
-				if (employeeInfoMap.find(it->second)->second->phoneNumMid != key) {
+				if (employeeInfoMap.find(it->second)->second->phoneNum_Mid != key) {
 					hashTable.erase(it++);
 					continue;
 				}
 				result.push_back(employeeInfoMap[it->second]);
 			}
 			else if (hash_name == "phoneNumEndMap") {
-				if (employeeInfoMap.find(it->second)->second->phoneNumEnd != key) {
+				if (employeeInfoMap.find(it->second)->second->phoneNum_End != key) {
 					hashTable.erase(it++);
 					continue;
 				}
 				result.push_back(employeeInfoMap[it->second]);
 			}
 			else if (hash_name == "birthYearMap") {
-				if (employeeInfoMap.find(it->second)->second->birthYear != key) {
+				if (employeeInfoMap.find(it->second)->second->birthday_Year != key) {
 					hashTable.erase(it++);
 					continue;
 				}
 				result.push_back(employeeInfoMap[it->second]);
 			}
 			else if (hash_name == "birthMonthMap") {
-				if (employeeInfoMap.find(it->second)->second->birthMonth != key) {
+				if (employeeInfoMap.find(it->second)->second->birthday_Month != key) {
 					hashTable.erase(it++);
 					continue;
 				}
 				result.push_back(employeeInfoMap[it->second]);
 			}
 			else if (hash_name == "birthDayMap") {
-				if (employeeInfoMap.find(it->second)->second->birthDay != key) {
+				if (employeeInfoMap.find(it->second)->second->birthday_Day != key) {
 					hashTable.erase(it++);
 					continue;
 				}
 				result.push_back(employeeInfoMap[it->second]);
 			}
 			else if (hash_name == "birthMap") {
-				if (employeeInfoMap.find(it->second)->second->birth != key) {
+				if (employeeInfoMap.find(it->second)->second->birthday != key) {
 					hashTable.erase(it++);
 					continue;
 				}

--- a/UnitTest/CommandParser_test.cpp
+++ b/UnitTest/CommandParser_test.cpp
@@ -29,18 +29,18 @@ TEST(CommandParserTest, parse_add) {
 
 	// ADD, , , ,15123099,VXIHXOTH JHOP,CL3,010-3112-2609,19771211,ADV
 	EXPECT_EQ(addInfo->employeeNum, 15123099);
-	EXPECT_EQ(addInfo->givenName, "VXIHXOTH");
-	EXPECT_EQ(addInfo->familyName, "JHOP");
+	EXPECT_EQ(addInfo->name_First, "VXIHXOTH");
+	EXPECT_EQ(addInfo->name_Last, "JHOP");
 	EXPECT_EQ(addInfo->cl, CareerLevel::CL3);
-	EXPECT_EQ(addInfo->phoneNumMid, 3112);
-	EXPECT_EQ(addInfo->phoneNumEnd, 2609);
-	EXPECT_EQ(addInfo->birthYear, 1977);
-	EXPECT_EQ(addInfo->birthMonth, 12);
-	EXPECT_EQ(addInfo->birthDay, 11);
+	EXPECT_EQ(addInfo->phoneNum_Mid, 3112);
+	EXPECT_EQ(addInfo->phoneNum_End, 2609);
+	EXPECT_EQ(addInfo->birthday_Year, 1977);
+	EXPECT_EQ(addInfo->birthday_Month, 12);
+	EXPECT_EQ(addInfo->birthday_Day, 11);
 	EXPECT_EQ(addInfo->certi, CERTI::ADV);
 	EXPECT_EQ(addInfo->name, "VXIHXOTH JHOP");
 	EXPECT_EQ(addInfo->phoneNum, "010-3112-2609");
-	EXPECT_EQ(addInfo->birth, 19771211);
+	EXPECT_EQ(addInfo->birthday, 19771211);
 }
 
 TEST(CommandParserTest, parse_mod) {
@@ -99,6 +99,7 @@ TEST(CommandParserTest, parse_sch) {
 	EXPECT_EQ(keyInfo->searchKeyword, "18115040");
 }
 
+
 TEST(CommandParserTest, parse_option) {
 	EmployeeManagement* em = new EmployeeManagement();
 	CommandParser* cp = new CommandParser();
@@ -113,7 +114,7 @@ TEST(CommandParserTest, parse_option) {
 	cp->parseSearchCommand(keyInfo, optionInfo);
 
 	// SCH,-p,-d, ,birthday,04
-	EXPECT_EQ(keyInfo->searchKey, "birthDay");
+	EXPECT_EQ(keyInfo->searchKey, "birthday_Day");
 	EXPECT_EQ(keyInfo->searchKeyword, "04");
 
 	cp->parseData(em->readLine[24]);
@@ -121,7 +122,7 @@ TEST(CommandParserTest, parse_option) {
 	cp->parseDeleteCommand(keyInfo, optionInfo);
 
 	// DEL,-p,-l, ,name,MPOSXU
-	EXPECT_EQ(keyInfo->searchKey, "familyName");
+	EXPECT_EQ(keyInfo->searchKey, "name_Last");
 	EXPECT_EQ(keyInfo->searchKeyword, "MPOSXU");
 
 	cp->parseData(em->readLine[28]);
@@ -129,7 +130,7 @@ TEST(CommandParserTest, parse_option) {
 	cp->parseSearchCommand(keyInfo, optionInfo);
 
 	// SCH, ,-m, ,birthday,09
-	EXPECT_EQ(keyInfo->searchKey, "birthMonth");
+	EXPECT_EQ(keyInfo->searchKey, "birthday_Month");
 	EXPECT_EQ(keyInfo->searchKeyword, "09");
 
 	cp->parseData(em->readLine[31]);
@@ -137,7 +138,7 @@ TEST(CommandParserTest, parse_option) {
 	cp->parseSearchCommand(keyInfo, optionInfo);
 
 	// SCH,-p,-y, ,birthday,2003
-	EXPECT_EQ(keyInfo->searchKey, "birthYear");
+	EXPECT_EQ(keyInfo->searchKey, "birthday_Year");
 	EXPECT_EQ(keyInfo->searchKeyword, "2003");
 
 	cp->parseData(em->readLine[33]);
@@ -145,7 +146,7 @@ TEST(CommandParserTest, parse_option) {
 	cp->parseSearchCommand(keyInfo, optionInfo);
 
 	// SCH,-p,-m, ,phoneNum,3112
-	EXPECT_EQ(keyInfo->searchKey, "phoneNumMid");
+	EXPECT_EQ(keyInfo->searchKey, "phoneNum_Mid");
 	EXPECT_EQ(keyInfo->searchKeyword, "3112");
 
 	cp->parseData(em->readLine[34]);
@@ -153,7 +154,7 @@ TEST(CommandParserTest, parse_option) {
 	cp->parseSearchCommand(keyInfo, optionInfo);
 
 	// SCH,-p,-l, ,phoneNum,4605
-	EXPECT_EQ(keyInfo->searchKey, "phoneNumEnd");
+	EXPECT_EQ(keyInfo->searchKey, "phoneNum_End");
 	EXPECT_EQ(keyInfo->searchKeyword, "4605");
 
 	cp->parseData(em->readLine[37]);
@@ -161,7 +162,7 @@ TEST(CommandParserTest, parse_option) {
 	cp->parseSearchCommand(keyInfo, optionInfo);
 
 	// SCH, ,-f, ,name,LDEXRI
-	EXPECT_EQ(keyInfo->searchKey, "givenName");
+	EXPECT_EQ(keyInfo->searchKey, "name_First");
 	EXPECT_EQ(keyInfo->searchKeyword, "LDEXRI");
 }
 
@@ -185,18 +186,18 @@ TEST(CommandParserTest, parse_addmodule) {
 	EmployeeInfo* employee = dm->employeeInfoMap.find(it->second)->second;
 	
 	EXPECT_EQ(employee->employeeNum, 15123099);
-	EXPECT_EQ(employee->givenName, "VXIHXOTH");
-	EXPECT_EQ(employee->familyName, "JHOP");
+	EXPECT_EQ(employee->name_First, "VXIHXOTH");
+	EXPECT_EQ(employee->name_Last, "JHOP");
 	EXPECT_EQ(employee->cl, CareerLevel::CL3);
-	EXPECT_EQ(employee->phoneNumMid, 3112);
-	EXPECT_EQ(employee->phoneNumEnd, 2609);
-	EXPECT_EQ(employee->birthYear, 1977);
-	EXPECT_EQ(employee->birthMonth, 12);
-	EXPECT_EQ(employee->birthDay, 11);
+	EXPECT_EQ(employee->phoneNum_Mid, 3112);
+	EXPECT_EQ(employee->phoneNum_End, 2609);
+	EXPECT_EQ(employee->birthday_Year, 1977);
+	EXPECT_EQ(employee->birthday_Month, 12);
+	EXPECT_EQ(employee->birthday_Day, 11);
 	EXPECT_EQ(employee->certi, CERTI::ADV);
 	EXPECT_EQ(employee->name, "VXIHXOTH JHOP");
 	EXPECT_EQ(employee->phoneNum, "010-3112-2609");
-	EXPECT_EQ(employee->birth, 19771211);
+	EXPECT_EQ(employee->birthday, 19771211);
 }
 
 TEST(CommandParserTest, parse_delmodule) {


### PR DESCRIPTION
- name,phoneNum,birthday의 분할 변수명의 혼선이 있어
  좀 더 명시적으로 변수 명을 수정 함
- CommandParser 쪽 key string 정보도 동일하게 수정하였으며
  Parser쪽 TDD TC는 확인 됨
- 다른 block의 string 정보는 각 담당자의 수정 필요