### PR TITLE
[TDD] dataManager_test test 모두 통과하게 수정

### DIFF
--- a/UnitTest/dataManager_test.cpp
+++ b/UnitTest/dataManager_test.cpp
@@ -9,7 +9,7 @@ TEST(dataManagerTest, employeeNumMapTest) {
 		bool ret = data_manager.addEmployee({ i, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), 3112, 2609, 77, 12, 11, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", 771211});  //사원번호가 i인 사람 생성
 	};  
 
-	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
+	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
 		auto iter = data_manager.employeeNumMap.find(i);
 		EXPECT_NE(iter, data_manager.employeeNumMap.end());
@@ -22,10 +22,10 @@ TEST(dataManagerTest, givenNameMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, to_string(i), "JHOP", static_cast<CareerLevel>(3), 3112, 2609, 77, 12, 11, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", 771211 });  //givenname이 i인 사람 생성
+		bool ret = data_manager.addEmployee({ i, to_string(i), "JHOP", static_cast<CareerLevel>(3), 3112, 2609, 77, 12, 11, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", 771211 });  //givenname이 i인 사람 생성
 	};
 
-	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
+	for (int i = 0; i < MAX_EMPLOYEE; i++) 
 	{
 		auto iter = data_manager.NameFisrtMap.find(to_string(i));
 		EXPECT_NE(iter, data_manager.NameFisrtMap.end());
@@ -38,10 +38,10 @@ TEST(dataManagerTest, familyNameMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", to_string(i), static_cast<CareerLevel>(3), 3112, 2609, 77, 12, 11, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", 771211 });  //familyname이 i인 사람 생성
+		bool ret = data_manager.addEmployee({ i, "VXIHXOTH", to_string(i), static_cast<CareerLevel>(3), 3112, 2609, 77, 12, 11, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", 771211 });  //familyname이 i인 사람 생성
 	};
 
-	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
+	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
 		auto iter = data_manager.NameLastMap.find(to_string(i));
 		EXPECT_NE(iter, data_manager.NameLastMap.end());
@@ -54,10 +54,10 @@ TEST(dataManagerTest, clMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", static_cast<CareerLevel>((i % 3) + 1), 3112, 2609, 77, 12, 11, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", 771211 });  //cl이 i%3+1인 사람 생성
+		bool ret = data_manager.addEmployee({ i, "VXIHXOTH", "JHOP", static_cast<CareerLevel>((i % 3) + 1), 3112, 2609, 77, 12, 11, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", 771211 });  //cl이 i%3+1인 사람 생성
 	};
 
-	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
+	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
 		auto iter = data_manager.clMap.find(static_cast<CareerLevel>(i % 3 + 1));
 		EXPECT_NE(iter, data_manager.clMap.end());
@@ -70,10 +70,10 @@ TEST(dataManagerTest, phoneNumMidMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), i, 2609, 77, 12, 11, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", 771211 });  //사원번호가 i인 사람 생성
+		bool ret = data_manager.addEmployee({ i, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), i, 2609, 77, 12, 11, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", 771211 });  //사원번호가 i인 사람 생성
 	};
 
-	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
+	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
 		auto iter = data_manager.phoneNumMidMap.find(i);
 		EXPECT_NE(iter, data_manager.phoneNumMidMap.end());
@@ -86,10 +86,10 @@ TEST(dataManagerTest, phoneNumEndMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), 3112, i, 77, 12, 11, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", 771211 });
+		bool ret = data_manager.addEmployee({ i, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), 3112, i, 77, 12, 11, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", 771211 });
 	};
 
-	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
+	for (int i = 0; i < MAX_EMPLOYEE; i++) 
 	{
 		auto iter = data_manager.phoneNumEndMap.find(i);
 		EXPECT_NE(iter, data_manager.phoneNumEndMap.end());
@@ -103,10 +103,10 @@ TEST(dataManagerTest, birthYearMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), 3112, 2609, i, 12, 11, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", 771211 });
+		bool ret = data_manager.addEmployee({ i, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), 3112, 2609, i, 12, 11, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", 771211 });
 	};
 
-	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
+	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
 		auto iter = data_manager.birthYearMap.find(i);
 		EXPECT_NE(iter, data_manager.birthYearMap.end());
@@ -120,10 +120,10 @@ TEST(dataManagerTest, birthMonthMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), 3112, 2609, 77, i, 11, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", 771211 });
+		bool ret = data_manager.addEmployee({ i, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), 3112, 2609, 77, i, 11, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", 771211 });
 	};
 
-	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
+	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
 		auto iter = data_manager.birthMonthMap.find(i);
 		EXPECT_NE(iter, data_manager.birthMonthMap.end());
@@ -136,10 +136,10 @@ TEST(dataManagerTest, birthDayMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), 3112, 2609, 77, 12, i, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", 771211 });
+		bool ret = data_manager.addEmployee({ i, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), 3112, 2609, 77, 12, i, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", 771211 });
 	};
 
-	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
+	for (int i = 0; i < MAX_EMPLOYEE; i++) 
 	{
 		auto iter = data_manager.birthDayMap.find(i);
 		EXPECT_NE(iter, data_manager.birthDayMap.end());
@@ -152,10 +152,10 @@ TEST(dataManagerTest,certiMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), 3112, 2609, 77, 12, 11, static_cast<CERTI>(i%4), "VXIHXOTH JHOP", "010-3112-2609", 771211 });
+		bool ret = data_manager.addEmployee({ i, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), 3112, 2609, 77, 12, 11, static_cast<CERTI>(i%4), "VXIHXOTH JHOP", "010-3112-2609", 771211 });
 	};
 
-	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
+	for (int i = 0; i < MAX_EMPLOYEE; i++) 
 	{
 		auto iter = data_manager.certiMap.find(static_cast<CERTI>(i % 4));
 		EXPECT_NE(iter, data_manager.certiMap.end());
@@ -168,10 +168,10 @@ TEST(dataManagerTest, nameMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), 3112, 2609, 77, 12, 11, CERTI::ADV, to_string(i), "010-3112-2609", 771211 });
+		bool ret = data_manager.addEmployee({ i, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), 3112, 2609, 77, 12, 11, CERTI::ADV, to_string(i), "010-3112-2609", 771211 });
 	};
 
-	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
+	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
 		auto iter = data_manager.nameMap.find(to_string(i));
 		EXPECT_NE(iter, data_manager.nameMap.end());
@@ -184,10 +184,10 @@ TEST(dataManagerTest, phoneNumMap) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), 3112, 2609, 77, 12, 11, CERTI::ADV, "VXIHXOTH JHOP", to_string(i), 771211 });
+		bool ret = data_manager.addEmployee({ i, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), 3112, 2609, 77, 12, 11, CERTI::ADV, "VXIHXOTH JHOP", to_string(i), 771211 });
 	};
 
-	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
+	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
 		auto iter = data_manager.phoneNumMap.find(to_string(i));
 		EXPECT_NE(iter, data_manager.phoneNumMap.end());
@@ -200,10 +200,10 @@ TEST(dataManagerTest, birthMapTest) {
 
 	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
-		bool ret = data_manager.addEmployee({ 15123099, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), 3112, 2609, 77, 12, 11, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", i });
+		bool ret = data_manager.addEmployee({ i, "VXIHXOTH", "JHOP", static_cast<CareerLevel>(3), 3112, 2609, 77, 12, 11, CERTI::ADV, "VXIHXOTH JHOP", "010-3112-2609", i });
 	};
 
-	for (int i = 0; i < MAX_EMPLOYEE; i++)  //Hash에 잘 저장되었는지 test
+	for (int i = 0; i < MAX_EMPLOYEE; i++)
 	{
 		auto iter = data_manager.birthMap.find(i);
 		EXPECT_NE(iter, data_manager.birthMap.end());


### PR DESCRIPTION
사번은 모두 다르다라는 조건을 추가하면서 dataManager_test의 10만개 input만드는 case를 모두 다른 사번을 사용하도록 변경하였습니다.